### PR TITLE
Audio or playlist is assigned when start is false

### DIFF
--- a/dartvlc/internal/setters.hpp
+++ b/dartvlc/internal/setters.hpp
@@ -44,11 +44,14 @@ public:
 			this->state->isPlaylist = true;
 		}
 		this->_onOpenCallback(this->mediaList.itemAtIndex(0));
-		if (autoStart) {
-			this->mediaListPlayer.playItemAtIndex(0);
-			this->state->index = 0;
-			this->state->isPlaying = this->mediaListPlayer.isPlaying();
-			this->state->isValid = this->mediaListPlayer.isValid();
+		
+		this->mediaListPlayer.playItemAtIndex(0);
+		this->state->index = 0;
+		this->state->isPlaying = this->mediaListPlayer.isPlaying();
+		this->state->isValid = this->mediaListPlayer.isValid();
+		
+		if (!autoStart) {
+			this->stop();
 		}
 	}
 


### PR DESCRIPTION
The problem in reference #32 is solved

Method **open**
```C++
  this->mediaListPlayer.playItemAtIndex(0);
  this->state->index = 0;
  this->state->isPlaying = this->mediaListPlayer.isPlaying();
  this->state->isValid = this->mediaListPlayer.isValid();
  
  if (!autoStart) {
	  this->stop();
  }
```
