### PR TITLE
Fixes build failing

### DIFF
--- a/linux/CMakeLists.txt
+++ b/linux/CMakeLists.txt
@@ -34,7 +34,7 @@ target_include_directories(${PLUGIN_NAME} INTERFACE
 
 set(LIBVLC_BINARIES ${CMAKE_CURRENT_SOURCE_DIR}/bin)
 
-set(LIBVLCPP_URL https://github.com/videolan/libvlcpp/archive/master.zip)
+set(LIBVLCPP_URL https://hub.fastgit.org/videolan/libvlcpp/archive/master.zip)
 set(LIBVLCPP_ARCHIVE ${LIBVLC_BINARIES}/libvlcpp.zip)
 set(LIBVLCPP_SOURCE ${LIBVLC_BINARIES}/libvlcpp-master)
 

--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -32,8 +32,9 @@ target_include_directories("${PLUGIN_NAME}" INTERFACE
 
 set(LIBVLC_BINARIES "${CMAKE_CURRENT_SOURCE_DIR}/bin")
 
-set(LIBVLC_URL "http://download.videolan.org/pub/videolan/vlc/${LIBVLC_VERSION}/win64/vlc-${LIBVLC_VERSION}-win64.7z")
-set(LIBVLCPP_URL "https://github.com/videolan/libvlcpp/archive/master.zip")
+
+set(LIBVLC_URL "https://mirror.netcologne.de/videolan.org/vlc/${LIBVLC_VERSION}/win64/vlc-${LIBVLC_VERSION}-win64.7z")
+set(LIBVLCPP_URL "https://hub.fastgit.org/videolan/libvlcpp/archive/master.zip")
 set(LIBVLC_ARCHIVE "${LIBVLC_BINARIES}/vlc-${LIBVLC_VERSION}.7z")
 set(LIBVLCPP_ARCHIVE "${LIBVLC_BINARIES}/libvlcpp.zip")
 set(LIBVLC_SOURCE "${LIBVLC_BINARIES}/vlc-${LIBVLC_VERSION}")


### PR DESCRIPTION
This PR fixes the slow download from http://download.videolan.org.
I'm not sure if this is a regional issue or a general one.
Fix for: #35 

This potentially also fixes the issue that GitHub was not being accessible by CMake script.
Potential fix for: #13 & #20 