### PR TITLE
Fix textures on Windows

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,3 @@
+BasedOnStyle: Google
+DerivePointerAlignment: false
+PointerAlignment: Left

--- a/windows/dart_vlc.cc
+++ b/windows/dart_vlc.cc
@@ -1,14 +1,16 @@
 /*
- * dart_vlc: A media playback library for Dart & Flutter. Based on libVLC & libVLC++.
- * 
+ * dart_vlc: A media playback library for Dart & Flutter. Based on libVLC &
+ * libVLC++.
+ *
  * Hitesh Kumar Saini
  * https://github.com/alexmercerind
  * saini123hitesh@gmail.com; alexmercerind@gmail.com
- * 
+ *
  * GNU Lesser General Public License v2.1
  */
 
 /* Standard headers. */
+#include <mutex>
 #include <unordered_map>
 /* Flutter headers */
 #include <flutter/method_channel.h>
@@ -19,94 +21,152 @@
 /* Main FFI __declspec(dllexport) methods. */
 #include "native/dart_vlc.cpp"
 
-
 std::unique_ptr<flutter::MethodChannel<flutter::EncodableValue>> channel;
-
 
 namespace {
 
+class VideoOutlet {
+ public:
+  VideoOutlet(size_t width, size_t height);
 
-    class DartVlcPlugin : public flutter::Plugin {
-    public:
-        static void RegisterWithRegistrar(flutter::PluginRegistrarWindows *registrar);
+  flutter::TextureVariant* texture() const { return texture_.get(); }
+  void OnFrame(const uint8_t* frame);
 
-        DartVlcPlugin(flutter::TextureRegistrar* textureRegistrar);
+ private:
+  const size_t buffer_size_;
+  mutable std::mutex mutex_;
+  std::unique_ptr<flutter::TextureVariant> texture_;
+  std::unique_ptr<uint8_t> buffer_;
+  FlutterDesktopPixelBuffer flutter_pixel_buffer_;
 
-        virtual ~DartVlcPlugin();
+  const FlutterDesktopPixelBuffer* CopyPixelBuffer() const;
+};
 
-    private:
-        void HandleMethodCall(const flutter::MethodCall<flutter::EncodableValue> &method_call, std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> result);
-        flutter::TextureRegistrar *textureRegistrar = nullptr;
-        std::unordered_map<int, uint8_t*> frames;
-        std::unordered_map<int, FlutterDesktopPixelBuffer*> buffers;
-        std::unordered_map<int, std::unique_ptr<flutter::TextureVariant>> textures;
-    };
+VideoOutlet::VideoOutlet(size_t width, size_t height)
+    : buffer_size_(width * height * 4 * sizeof(uint8_t)),
+      buffer_(new uint8_t[buffer_size_]) {
+  memset(buffer_.get(), 0, buffer_size_);
 
+  flutter_pixel_buffer_.width = width;
+  flutter_pixel_buffer_.height = height;
+  flutter_pixel_buffer_.buffer = buffer_.get();
 
-    void DartVlcPlugin::RegisterWithRegistrar(flutter::PluginRegistrarWindows *registrar) {
-        channel = std::make_unique<flutter::MethodChannel<flutter::EncodableValue>>(registrar->messenger(), "dart_vlc", &flutter::StandardMethodCodec::GetInstance());
-        auto plugin = std::make_unique<DartVlcPlugin>(registrar->texture_registrar());
-        channel->SetMethodCallHandler(
-            [plugin_pointer = plugin.get()](const auto &call, auto result) {
-                plugin_pointer->HandleMethodCall(call, std::move(result));
-            }
-        );
-        registrar->AddPlugin(std::move(plugin));
-    }
-
-    DartVlcPlugin::DartVlcPlugin(flutter::TextureRegistrar* textureRegistrar): textureRegistrar(textureRegistrar) {}
-
-    DartVlcPlugin::~DartVlcPlugin() {}
-
-    void DartVlcPlugin::HandleMethodCall(const flutter::MethodCall<flutter::EncodableValue> &methodCall, std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> result) {
-        /* No platform channel implementation after migration to FFI except Player::onVideo callbacks for Texture. */
-
-        /* Sets lambda for Player::onVideo callbacks. Called after creating new instance of Player. */
-        if (methodCall.method_name() == "Player.onVideo") {
-            flutter::EncodableMap arguments = std::get<flutter::EncodableMap>(*methodCall.arguments());
-            int playerId = std::get<int>(arguments[flutter::EncodableValue("playerId")]);
-            Player* player = players->get(playerId);
-            this->frames.insert(
-                std::make_pair(playerId, new uint8_t[player->videoHeight * player->videoWidth * 4])
-            );
-            memset(this->frames.at(playerId), 0, player->videoHeight * player->videoWidth * 4 * sizeof(uint8_t));
-            this->buffers.insert(
-                std::make_pair(playerId, new FlutterDesktopPixelBuffer())
-            );
-            this->buffers.at(playerId)->width = player->videoWidth;
-            this->buffers.at(playerId)->height = player->videoHeight;
-            this->buffers.at(playerId)->buffer = this->frames.at(playerId);
-            this->textures[playerId] = std::make_unique<flutter::TextureVariant>(
-                flutter::PixelBufferTexture(
-                    [=](size_t width, size_t height) -> const FlutterDesktopPixelBuffer* {
-                        return this->buffers.at(playerId);
-                    }
-                )
-            );
-            int64_t textureId = this->textureRegistrar->RegisterTexture(this->textures[playerId].get());
-            this->textureRegistrar->MarkTextureFrameAvailable(textureId);
-            player->onVideo(
-                [=](uint8_t* frame) -> void {
-                    memcpy(this->frames.at(playerId), frame, player->videoHeight * player->videoWidth * 4 * sizeof(uint8_t));
-                    this->textureRegistrar->MarkTextureFrameAvailable(textureId);
-                }
-            );
-            result->Success(flutter::EncodableValue(textureId));
-        }
-        /* Called after disposing a Player instance. */
-        else if (methodCall.method_name() == "Player.dispose") {
-            flutter::EncodableMap arguments = std::get<flutter::EncodableMap>(*methodCall.arguments());
-            int playerId = std::get<int>(arguments[flutter::EncodableValue("playerId")]);
-            delete this->frames.at(playerId);
-            delete this->buffers.at(playerId);
-            result->Success(flutter::EncodableValue(nullptr));
-        }
-        else {
-            result->NotImplemented();
-        }
-    }
+  texture_ =
+      std::make_unique<flutter::TextureVariant>(flutter::PixelBufferTexture(
+          [=](size_t width, size_t height) -> const FlutterDesktopPixelBuffer* {
+            return CopyPixelBuffer();
+          }));
 }
 
-void DartVlcPluginRegisterWithRegistrar(FlutterDesktopPluginRegistrarRef registrar) {
-    DartVlcPlugin::RegisterWithRegistrar(flutter::PluginRegistrarManager::GetInstance()->GetRegistrar<flutter::PluginRegistrarWindows>(registrar));
+void VideoOutlet::OnFrame(const uint8_t* buffer) {
+  const std::lock_guard<std::mutex> lock(mutex_);
+  memcpy(buffer_.get(), buffer, buffer_size_);
+}
+
+const FlutterDesktopPixelBuffer* VideoOutlet::CopyPixelBuffer() const {
+  const std::lock_guard<std::mutex> lock(mutex_);
+  return &flutter_pixel_buffer_;
+}
+
+class DartVlcPlugin : public flutter::Plugin {
+ public:
+  static void RegisterWithRegistrar(flutter::PluginRegistrarWindows* registrar);
+
+  DartVlcPlugin(flutter::TextureRegistrar* textureRegistrar);
+
+  virtual ~DartVlcPlugin();
+
+ private:
+  void HandleMethodCall(
+      const flutter::MethodCall<flutter::EncodableValue>& method_call,
+      std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> result);
+  flutter::TextureRegistrar* textureRegistrar = nullptr;
+  std::unordered_map<int, std::pair<int64_t, std::shared_ptr<VideoOutlet>>>
+      outlets;
+};
+
+void DartVlcPlugin::RegisterWithRegistrar(
+    flutter::PluginRegistrarWindows* registrar) {
+  channel = std::make_unique<flutter::MethodChannel<flutter::EncodableValue>>(
+      registrar->messenger(), "dart_vlc",
+      &flutter::StandardMethodCodec::GetInstance());
+  auto plugin = std::make_unique<DartVlcPlugin>(registrar->texture_registrar());
+  channel->SetMethodCallHandler(
+      [plugin_pointer = plugin.get()](const auto& call, auto result) {
+        plugin_pointer->HandleMethodCall(call, std::move(result));
+      });
+  registrar->AddPlugin(std::move(plugin));
+}
+
+DartVlcPlugin::DartVlcPlugin(flutter::TextureRegistrar* textureRegistrar)
+    : textureRegistrar(textureRegistrar) {}
+
+DartVlcPlugin::~DartVlcPlugin() {}
+
+void DartVlcPlugin::HandleMethodCall(
+    const flutter::MethodCall<flutter::EncodableValue>& methodCall,
+    std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> result) {
+  /* No platform channel implementation after migration to FFI except
+   * Player::onVideo callbacks for Texture. */
+
+  /* Sets lambda for Player::onVideo callbacks. Called after creating new
+   * instance of Player. */
+  if (methodCall.method_name() == "createTexture") {
+    flutter::EncodableMap arguments =
+        std::get<flutter::EncodableMap>(*methodCall.arguments());
+    int player_id =
+        std::get<int>(arguments[flutter::EncodableValue("playerId")]);
+
+    auto [it, added] =
+        outlets.try_emplace(player_id, std::make_pair(0, nullptr));
+    if (added) {
+      auto player = players->get(player_id);
+      auto outlet = std::make_shared<VideoOutlet>(player->videoWidth,
+                                                  player->videoHeight);
+      auto texture_id = textureRegistrar->RegisterTexture(outlet->texture());
+
+      it->second = std::make_pair(texture_id, std::move(outlet));
+      // TODO: The weak_ptr might not be needed anymore once callbacks can be
+      // unregistered.
+      player->onVideo([=, weak_outlet = std::weak_ptr<VideoOutlet>(
+                              it->second.second)](uint8_t* frame) -> void {
+        if (auto outlet = weak_outlet.lock()) {
+          outlet->OnFrame(frame);
+          textureRegistrar->MarkTextureFrameAvailable(texture_id);
+        }
+      });
+
+      textureRegistrar->MarkTextureFrameAvailable(texture_id);
+      return result->Success(flutter::EncodableValue(texture_id));
+    }
+
+    result->Error("Texture was already registered");
+  }
+  /* Called after disposing a Player instance. */
+  else if (methodCall.method_name() == "disposeTexture") {
+    flutter::EncodableMap arguments =
+        std::get<flutter::EncodableMap>(*methodCall.arguments());
+    int player_id =
+        std::get<int>(arguments[flutter::EncodableValue("playerId")]);
+
+    auto it = outlets.find(player_id);
+    if (it != outlets.end()) {
+      auto texture_id = it->second.first;
+      textureRegistrar->UnregisterTexture(texture_id);
+      outlets.erase(it);
+    }
+
+    result->Success(flutter::EncodableValue(nullptr));
+
+  } else {
+    result->NotImplemented();
+  }
+}
+}  // namespace
+
+void DartVlcPluginRegisterWithRegistrar(
+    FlutterDesktopPluginRegistrarRef registrar) {
+  DartVlcPlugin::RegisterWithRegistrar(
+      flutter::PluginRegistrarManager::GetInstance()
+          ->GetRegistrar<flutter::PluginRegistrarWindows>(registrar));
 }


### PR DESCRIPTION
I found a few issues with textures on Windows this PR attempts to fix.

#### Issues addressed:

- The `Video` widget did not wait for the `Player.textureId` to get populated. It now wraps the texture ID with a `ValueNotifier` which allows the `Video` widget to wait for the texture ID using a `ValueListenableBuilder`.
- The widget also behaved inconsistently depending on the platform (Windows or not) and `showControls` being enabled or not.
- The Dart side never called the message channel method "Player.dispose" for unregistering the texture from the texture registrar.
- Access to the raw pixel buffer that gets written in `dart_vlc.cc` by the player frame callback and read by the Flutter read pixel callback was not synchronized. However, as far as I remember, the Flutter pixel buffer callback gets called on the Flutter engine's UI thread and thus needs synchronization.
- As far a I can see, callbacks for the Player's `onVideo` can't be unregistered once set. Therefore the player's `onVideo` callback will continue calling `MarkTextureFrameAvailable` with a now invalid texture ID -> I've changed that part to use a weak_ptr for checking if the flutter texture is still valid.


#### Things that can be potentially optimized:

- There's one unnecessary pixel copy operation when using the texture registrar API:
     * hint: Pixels get copied from VLC to `_videoFrameBuffer` in `PlayerEvents` (`dartvlc/internal/events.hpp`) before getting copied a second time to the `FlutterDesktopPixelBuffer`. So the code could be refactored in a way that VLC can directly write to the `FlutterDesktopPixelBuffer`'s backing pixel array. The 3 lock/unlock/display callbacks that can be provided to VLC should help taking care of proper synchronization.





Besides, I've noticed that you're using raw pointers and deleting objects manually (mostly in `dartvlc/**/*.hpp`) as opposed to using smart pointers. Generally this is strongly discouraged in modern C++.
Example:

- https://github.com/alexmercerind/dart_vlc/blob/185d383de0c0050c4fa0010af976a7d6eaa42d82/dartvlc/player.hpp#L88
- https://github.com/alexmercerind/dart_vlc/blob/185d383de0c0050c4fa0010af976a7d6eaa42d82/dartvlc/player.hpp#L82


Btw., I've just bought you a coffee to keep you motivated 😃