### PR TITLE
Start migrating to smart ptrs

### DIFF
--- a/dartvlc/chromecast.hpp
+++ b/dartvlc/chromecast.hpp
@@ -8,13 +8,13 @@
  * GNU Lesser General Public License v2.1
 */
 
+#ifndef Chromecast_HEADER
+#define Chromecast_HEADER
+
 #include <string>
 #include <sstream>
 
 #include "mediasource/media.hpp"
-
-#ifndef Chromecast_HEADER
-#define Chromecast_HEADER
 
 class Chromecast {
 public:

--- a/dartvlc/mediasource/media.hpp
+++ b/dartvlc/mediasource/media.hpp
@@ -47,6 +47,7 @@ class Media : public MediaSource {
       return std::unique_ptr<Media>(Media::directShow(url));
   }
 
+  // TODO: Return std::unique_ptr<Media>
   static Media* file(std::string path, bool parse = false,
                      int timeout = 10000) {
     Media* media = new Media();
@@ -57,6 +58,7 @@ class Media : public MediaSource {
     return media;
   }
 
+  // TODO: Return std::unique_ptr<Media>
   static Media* network(std::string url, bool parse = false,
                         int timeout = 10000) {
     Media* media = new Media();
@@ -67,6 +69,7 @@ class Media : public MediaSource {
     return media;
   }
 
+  // TODO: Return std::unique_ptr<Media>
   static Media* directShow(std::string resource) {
     Media* media = new Media();
     media->resource = resource;

--- a/dartvlc/mediasource/media.hpp
+++ b/dartvlc/mediasource/media.hpp
@@ -9,6 +9,9 @@
  * GNU Lesser General Public License v2.1
  */
 
+#ifndef Media_HEADER
+#define Media_HEADER
+
 #include <filesystem>
 #include <future>
 #include <map>
@@ -17,9 +20,6 @@
 #include <vlcpp/vlc.hpp>
 
 #include "mediasource.hpp"
-
-#ifndef Media_HEADER
-#define Media_HEADER
 
 VLC::Instance instance = VLC::Instance(0, nullptr);
 

--- a/dartvlc/mediasource/media.hpp
+++ b/dartvlc/mediasource/media.hpp
@@ -1,18 +1,19 @@
 /*
- * dart_vlc: A media playback library for Dart & Flutter. Based on libVLC & libVLC++.
- * 
+ * dart_vlc: A media playback library for Dart & Flutter. Based on libVLC &
+ * libVLC++.
+ *
  * Hitesh Kumar Saini
  * https://github.com/alexmercerind
  * saini123hitesh@gmail.com; alexmercerind@gmail.com
- * 
+ *
  * GNU Lesser General Public License v2.1
  */
 
-#include <string>
-#include <map>
 #include <filesystem>
 #include <future>
-
+#include <map>
+#include <string>
+#include <string_view>
 #include <vlcpp/vlc.hpp>
 
 #include "mediasource.hpp"
@@ -22,101 +23,107 @@
 
 VLC::Instance instance = VLC::Instance(0, nullptr);
 
-
 /* Media object is cleared inside PlayerSetters::open. */
-class Media: public MediaSource {
-public:
-	int id;
-	std::string mediaType;
-	std::string resource;
-	std::string location;
-	std::map<std::string, std::string> metas;
+class Media : public MediaSource {
+ public:
+  std::string mediaType;
+  std::string resource;
+  std::string location;
+  std::map<std::string, std::string> metas;
 
-	static Media* file(int id, std::string path, bool parse = false, int timeout = 10000) {
-		Media* media = new Media();
-		media->id = id;
-		media->resource = path;
-		media->location = "file:///" + path;
-		media->mediaType = "MediaType.file";
-		if (parse) media->parse(timeout);
-		return media;
-	}
+  static constexpr auto kMediaTypeFile = "MediaType.file";
+  static constexpr auto kMediaTypeNetwork = "MediaType.network";
+  static constexpr auto kMediaTypeDirectShow = "MediaType.directShow";
 
-	static Media* network(int id, std::string url, bool parse = false, int timeout = 10000) {
-		Media* media = new Media();
-		media->id = id;
-		media->resource = url;
-		media->location = url;
-		media->mediaType = "MediaType.network";
-		if (parse) media->parse(timeout);
-		return media;
-	}
+  int64_t id() const { return reinterpret_cast<int64_t>(this); }
 
-	static Media* directShow(int id, std::string resource) {
-		Media* media = new Media();
-		media->id = id;
-		media->resource = resource;
-		media->location = resource;
-		media->mediaType = "MediaType.directShow";
-		return media;
-	}
+  static std::unique_ptr<Media> create(std::string_view type,
+                                       const std::string& url, bool parse = false) {
+    if (type.compare(kMediaTypeFile) == 0)
+      return std::unique_ptr<Media>(Media::file(url, parse));
+    else if (type.compare(kMediaTypeNetwork) == 0)
+      return std::unique_ptr<Media>(Media::network(url, parse));
+    else
+      return std::unique_ptr<Media>(Media::directShow(url));
+  }
 
-	/* Now done directly from dart_vlc.
-	static Media* asset(int id, std::string path, bool parse = false, int timeout = 10000) {
-		Media* media = new Media();
-		media->id = id;
-		media->resource = path;
-		media->location = "file:///" + std::filesystem::temp_directory_path().u8string() + "/" + path;
-		media->mediaType = "MediaType.asset";
-		if (parse) media->parse(timeout);
-		return media;
-	}
-	*/
+  static Media* file(std::string path, bool parse = false,
+                     int timeout = 10000) {
+    Media* media = new Media();
+    media->resource = path;
+    media->location = "file:///" + path;
+    media->mediaType = kMediaTypeFile;
+    if (parse) media->parse(timeout);
+    return media;
+  }
 
-	void parse(int timeout) {
-		VLC::Media media = VLC::Media(instance, this->location, VLC::Media::FromLocation);
-		std::promise<bool>* isParsed = new std::promise<bool>();
-		media.eventManager().onParsedChanged(
-			[isParsed](VLC::Media::ParsedStatus status) -> void {
-				isParsed->set_value(true);
-			}
-		);
-		media.parseWithOptions(
-			VLC::Media::ParseFlags::Network,
-			timeout
-		);
-		isParsed->get_future().wait();
-		this->metas["title"]       = media.meta(libvlc_meta_Title);
-		this->metas["artist"]      = media.meta(libvlc_meta_Artist);
-		this->metas["genre"]       = media.meta(libvlc_meta_Genre);
-		this->metas["copyright"]   = media.meta(libvlc_meta_Copyright);
-		this->metas["album"]       = media.meta(libvlc_meta_Album);
-		this->metas["trackNumber"] = media.meta(libvlc_meta_TrackNumber);
-		this->metas["description"] = media.meta(libvlc_meta_Description);
-		this->metas["rating"]      = media.meta(libvlc_meta_Rating);
-		this->metas["date"]        = media.meta(libvlc_meta_Date);
-		this->metas["settings"]    = media.meta(libvlc_meta_Setting);
-		this->metas["url"]         = media.meta(libvlc_meta_URL);
-		this->metas["language"]    = media.meta(libvlc_meta_Language);
-		this->metas["nowPlaying"]  = media.meta(libvlc_meta_NowPlaying);
-		this->metas["encodedBy"]   = media.meta(libvlc_meta_EncodedBy);
-		this->metas["artworkUrl"]  = media.meta(libvlc_meta_ArtworkURL);
-		this->metas["trackTotal"]  = media.meta(libvlc_meta_TrackTotal);
-		this->metas["director"]    = media.meta(libvlc_meta_Director);
-		this->metas["season"]      = media.meta(libvlc_meta_Season);
-		this->metas["episode"]     = media.meta(libvlc_meta_Episode);
-		this->metas["actors"]      = media.meta(libvlc_meta_Actors);
-		this->metas["albumArtist"] = media.meta(libvlc_meta_AlbumArtist);
-		this->metas["discNumber"]  = media.meta(libvlc_meta_DiscNumber);
-		this->metas["discTotal"]   = media.meta(libvlc_meta_DiscTotal);
-		this->metas["duration"]    = std::to_string(media.duration());
-		delete isParsed;
-	}
+  static Media* network(std::string url, bool parse = false,
+                        int timeout = 10000) {
+    Media* media = new Media();
+    media->resource = url;
+    media->location = url;
+    media->mediaType = kMediaTypeNetwork;
+    if (parse) media->parse(timeout);
+    return media;
+  }
 
-	std::string mediaSourceType() {
-		return "MediaSourceType.media";
-	}
+  static Media* directShow(std::string resource) {
+    Media* media = new Media();
+    media->resource = resource;
+    media->location = resource;
+    media->mediaType = kMediaTypeDirectShow;
+    return media;
+  }
+
+  /* Now done directly from dart_vlc.
+  static Media* asset(int id, std::string path, bool parse = false, int timeout
+  = 10000) { Media* media = new Media(); media->id = id; media->resource = path;
+          media->location = "file:///" +
+  std::filesystem::temp_directory_path().u8string() + "/" + path;
+          media->mediaType = "MediaType.asset";
+          if (parse) media->parse(timeout);
+          return media;
+  }
+  */
+
+  void parse(int timeout) {
+    VLC::Media media =
+        VLC::Media(instance, this->location, VLC::Media::FromLocation);
+    std::promise<bool>* isParsed = new std::promise<bool>();
+    media.eventManager().onParsedChanged(
+        [isParsed](VLC::Media::ParsedStatus status) -> void {
+          isParsed->set_value(true);
+        });
+    media.parseWithOptions(VLC::Media::ParseFlags::Network, timeout);
+    isParsed->get_future().wait();
+    this->metas["title"] = media.meta(libvlc_meta_Title);
+    this->metas["artist"] = media.meta(libvlc_meta_Artist);
+    this->metas["genre"] = media.meta(libvlc_meta_Genre);
+    this->metas["copyright"] = media.meta(libvlc_meta_Copyright);
+    this->metas["album"] = media.meta(libvlc_meta_Album);
+    this->metas["trackNumber"] = media.meta(libvlc_meta_TrackNumber);
+    this->metas["description"] = media.meta(libvlc_meta_Description);
+    this->metas["rating"] = media.meta(libvlc_meta_Rating);
+    this->metas["date"] = media.meta(libvlc_meta_Date);
+    this->metas["settings"] = media.meta(libvlc_meta_Setting);
+    this->metas["url"] = media.meta(libvlc_meta_URL);
+    this->metas["language"] = media.meta(libvlc_meta_Language);
+    this->metas["nowPlaying"] = media.meta(libvlc_meta_NowPlaying);
+    this->metas["encodedBy"] = media.meta(libvlc_meta_EncodedBy);
+    this->metas["artworkUrl"] = media.meta(libvlc_meta_ArtworkURL);
+    this->metas["trackTotal"] = media.meta(libvlc_meta_TrackTotal);
+    this->metas["director"] = media.meta(libvlc_meta_Director);
+    this->metas["season"] = media.meta(libvlc_meta_Season);
+    this->metas["episode"] = media.meta(libvlc_meta_Episode);
+    this->metas["actors"] = media.meta(libvlc_meta_Actors);
+    this->metas["albumArtist"] = media.meta(libvlc_meta_AlbumArtist);
+    this->metas["discNumber"] = media.meta(libvlc_meta_DiscNumber);
+    this->metas["discTotal"] = media.meta(libvlc_meta_DiscTotal);
+    this->metas["duration"] = std::to_string(media.duration());
+    delete isParsed;
+  }
+
+  std::string mediaSourceType() { return "MediaSourceType.media"; }
 };
-
 
 #endif

--- a/ffi/native/dart_vlc.cpp
+++ b/ffi/native/dart_vlc.cpp
@@ -285,19 +285,15 @@ EXPORT void Chromecast_dispose(int id) {
 }
 
 EXPORT void Record_create(int id, const char* savingFile, const char* type, const char* resource) {
-    Media* media;
-    /* Freed inside ~Record (Records::dispose) */
-    if (strcmp(type, "MediaType.file") == 0)
-        media = Media::file(resource, false);
-    else if (strcmp(type, "MediaType.network") == 0)
-        media = Media::network(resource, false);
-    else
-        media = Media::directShow(resource);
-    records->get(id, media, savingFile);
+    auto media = Media::create(type, resource);
+    records->create(id, std::move(media), savingFile);
 }
 
 EXPORT void Record_start(int id) {
-    records->get(id, nullptr, "")->start();
+    auto record = records->get(id);
+    if(record) {
+        record->start();
+    }
 }
 
 EXPORT void Record_dispose(int id) {

--- a/ffi/native/dart_vlc.cpp
+++ b/ffi/native/dart_vlc.cpp
@@ -245,7 +245,7 @@ EXPORT void Media_clear() {
 EXPORT void Broadcast_create(int id, const char* type, const char* resource, const char* access, const char* mux, const char* dst, const char* vcodec, int vb, const char* acodec, int ab) {
     auto media = Media::create(type, resource);
 
-    BroadcastConfiguration configuration(
+    auto configuration = std::make_unique<BroadcastConfiguration>(
         access,
         mux,
         dst,
@@ -254,7 +254,7 @@ EXPORT void Broadcast_create(int id, const char* type, const char* resource, con
         acodec,
         ab
     );
-    broadcasts->create(id, std::move(media), &configuration);
+    broadcasts->create(id, std::move(media), std::move(configuration));
 }
 
 EXPORT void Broadcast_start(int id) {


### PR DESCRIPTION
A first attempt of migrating to smart pointers. Works, but is still in progress.

`dartvlc/broadcast.hpp`, `dartvlc/chromecast.hpp` and the `Media::XXX` factory methods are partially fixed.
`dartvlc/record.hpp` and the Player+Playlist stuff are still pending.
