### PR TITLE
Windows: Fix method name typo

### DIFF
--- a/lib/dart_vlc.dart
+++ b/lib/dart_vlc.dart
@@ -68,7 +68,7 @@ class Player extends FFI.Player {
   @override
   void dispose() async {
     if (Platform.isWindows && textureId.value != null) {
-      await _channel.invokeMethod('PlayerUnegisterTexture', {'playerId': id});
+      await _channel.invokeMethod('PlayerUnregisterTexture', {'playerId': id});
       textureId.value = null;
     }
 


### PR DESCRIPTION
Fixes #112 