### PR TITLE
Windows: Initialize FlutterDesktopPixelBuffer

### DIFF
--- a/windows/video_outlet.h
+++ b/windows/video_outlet.h
@@ -1,5 +1,5 @@
-#ifndef VIDEO_OUTLET_H
-#define VIDEO_OUTLET_H
+#ifndef VIDEO_OUTLET_H_
+#define VIDEO_OUTLET_H_
 
 #include <flutter/method_channel.h>
 #include <flutter/plugin_registrar_windows.h>
@@ -18,7 +18,7 @@ class VideoOutlet {
   ~VideoOutlet();
 
  private:
-  FlutterDesktopPixelBuffer flutter_pixel_buffer_;
+  FlutterDesktopPixelBuffer flutter_pixel_buffer_{};
   flutter::TextureRegistrar* texture_registrar_ = nullptr;
   std::unique_ptr<flutter::TextureVariant> texture_ = nullptr;
   int64_t texture_id_;


### PR DESCRIPTION
Flutter might call the pixel buffer callback irrespective of calling `MarkTextureFrameAvailable`. So the `VideoOutlet`'s `flutter_pixel_buffer_` needs to be initialized to prevent issues like:

![image](https://user-images.githubusercontent.com/720469/130044010-c0b3bc2b-33bd-4713-8277-8c294a668a4b.png)

(which kept occurring until the first video frame arrived)