### PR TITLE
Fix race in texture unregistration

### DIFF
--- a/dartvlc/player.h
+++ b/dartvlc/player.h
@@ -12,25 +12,31 @@
 #ifndef PLAYER_H_
 #define PLAYER_H_
 
+#include <memory>
+#include <mutex>
+
 #include "internal/setters.h"
 
-auto TO_CHARARRAY = [](std::vector<std::string>& vector) -> char** {
+static auto TO_CHARARRAY(const std::vector<std::string>& vector) {
   size_t size = vector.size();
-  char** array = new char*[size];
-  for (int32_t i = 0; i < size; i++) array[i] = vector[i].data();
+  auto array = std::unique_ptr<const char*[]>(new const char*[size]);
+
+  for (auto i = 0; i < size; i++) {
+    array[i] = vector[i].c_str();
+  }
+
   return array;
-};
+}
 
 class Player : public PlayerSetters {
  public:
-  Player(std::vector<std::string> cmd_arguments = {}) {
+  Player(const std::vector<std::string>& cmd_arguments) {
     if (cmd_arguments.empty()) {
       vlc_instance_ = VLC::Instance(0, nullptr);
     } else {
-      char** args = TO_CHARARRAY(cmd_arguments);
+      auto args = TO_CHARARRAY(cmd_arguments);
       vlc_instance_ =
-          VLC::Instance(static_cast<int32_t>(cmd_arguments.size()), args);
-      delete[] args;
+          VLC::Instance(static_cast<int32_t>(cmd_arguments.size()), args.get());
     }
     vlc_media_player_ = VLC::MediaPlayer(vlc_instance_);
     vlc_media_list_player_ = VLC::MediaListPlayer(vlc_instance_);
@@ -46,16 +52,21 @@ class Player : public PlayerSetters {
 class Players {
  public:
   Player* Get(int32_t id, std::vector<std::string> cmd_arguments = {}) {
-    auto it = players_.find(id);
-    if (it == players_.end()) {
-      players_[id] = std::make_unique<Player>(cmd_arguments);
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto [it, added] = players_.try_emplace(id, nullptr);
+    if (added) {
+      it->second = std::make_unique<Player>(cmd_arguments);
     }
-    return players_[id].get();
+    return it->second.get();
   }
 
-  void Dispose(int32_t id) { players_.erase(id); }
+  void Dispose(int32_t id) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    players_.erase(id);
+  }
 
  private:
+  std::mutex mutex_;
   std::map<int32_t, std::unique_ptr<Player>> players_;
 };
 


### PR DESCRIPTION
While testing the stability by creating/disposing hundreds of players in a loop, I encountered a few issues (mostly affecting Windows).

The main issue was that the Windows `onVideo` handler attempted to blindly fetch a VideoOutlet from the map, without checking if it still exists (making the app crash).
I did a few changes to allow the Windows plugin to unregister its `onVideo` handler when unregistering the texture. Besides, I made `PlayerRegisterTexture` idempotent, i.e. it always returns the texture ID even if the texture was already created (working around hot reload issues).

Furthermore, I updated the `Players` registrar to synchronize access to its map as I ran into concurrency issues (the check if the player exists succeeded, but the subsequent attempt to fetch it from the map failed and made the app crash).