### PR TITLE
Windows: Allow controlling which plugins get copied

### DIFF
--- a/dartvlc/CMakeLists.txt
+++ b/dartvlc/CMakeLists.txt
@@ -25,11 +25,34 @@ if(NOT _HAS_PARENT_DIRECTORY)
   set(IS_STANDALONE TRUE)
 endif()
 
-if (NOT EXISTS "${LIBVLC_SOURCE}" OR NOT EXISTS "${LIBVLCPP_SOURCE}")
+if (NOT EXISTS "${LIBVLC_SOURCE}")
+  if(NOT WIN32)
+    # Headers only.
+    set(LIBVLC_FILES sdk)
+  else()
+    if(DARTVLC_VLC_PLUGINS)
+      list(TRANSFORM DARTVLC_VLC_PLUGINS PREPEND "plugins/")
+    else()
+      # Extract the whole plugins directory
+      # by default
+      set(DARTVLC_VLC_PLUGINS plugins)
+    endif()
+
+    set(LIBVLC_FILES
+      sdk
+      libvlc.dll
+      libvlccore.dll
+      ${DARTVLC_VLC_PLUGINS}
+    )
+  endif()
+
+  set(LIBVLC_ARCHIVE_ROOT "vlc-${LIBVLC_VERSION}/")
+  list(TRANSFORM LIBVLC_FILES PREPEND ${LIBVLC_ARCHIVE_ROOT})
+
   file(MAKE_DIRECTORY ${LIBVLC_PACKAGE_DIR})
   add_custom_command(
     TARGET LIBVLC_EXTRACT PRE_BUILD
-    COMMAND ${CMAKE_COMMAND} -E tar xzf \"${LIBVLC_ARCHIVE}\"
+    COMMAND ${CMAKE_COMMAND} -E tar xzf \"${LIBVLC_ARCHIVE}\" -- ${LIBVLC_FILES}
     WORKING_DIRECTORY "${LIBVLC_PACKAGE_DIR}"
     DEPENDS "${LIBVLC_ARCHIVE}" "${LIBVLCPP_ARCHIVE}"
   )
@@ -71,10 +94,9 @@ if(WIN32)
   )
 
   # Add generated shared library & libVLC DLLs.
-  set(DARTVLC_CORE_LIBS 
+  set(DARTVLC_CORE_LIBS
     # In case we decide to build this as a shared library
     #"$<TARGET_FILE:dart_vlc_core>"
-    
     "${LIBVLC_SOURCE}/libvlc.dll"
     "${LIBVLC_SOURCE}/libvlccore.dll"
     "${LIBVLC_SOURCE}/plugins"


### PR DESCRIPTION
* Limit libvlc extraction scope to headers only (unless it's a Win32 build)
* Allow controlling which libvlc plugins get extracted (and copied to the output directory) on Windows:
  If the top-level CMakeLists.txt defines `DARTVLC_VLC_PLUGINS` this will limit the scope of plugins to the specified ones (as opposed 
  to extracting all plugins)
  
  Example: 
  ```cmake
  # The paths must be relative to the libvlc "plugins" directory.
  set(DARTVLC_VLC_PLUGINS,
    "access/libfilesystem_plugin.dll"
    "demux/libh26x_plugin.dll"
    "video_output/libvmem_plugin.dll"
    ...
  )