### PR TITLE
Add fullscreen controls & Player::TakeSnapshot

### DIFF
--- a/dartvlc/api/api.cc
+++ b/dartvlc/api/api.cc
@@ -219,6 +219,12 @@ void PlayerMove(int32_t id, int32_t initial_index, int32_t final_index) {
   player->Move(initial_index, final_index);
 }
 
+void PlayerTakeSnapshot(int32_t id, const char* file_path, int32_t width,
+                        int32_t height) {
+  Player* player = g_players->Get(id);
+  player->TakeSnapshot(file_path, width, height);
+}
+
 void MediaClearMap(void*, void* peer) {
   delete reinterpret_cast<std::map<std::string, std::string>*>(peer);
 }

--- a/dartvlc/api/api.h
+++ b/dartvlc/api/api.h
@@ -88,6 +88,9 @@ DLLEXPORT void PlayerInsert(int32_t id, int32_t index, const char* type,
 DLLEXPORT void PlayerMove(int32_t id, int32_t initial_index,
                           int32_t final_index);
 
+DLLEXPORT void PlayerTakeSnapshot(int32_t id, const char* file_path,
+                                  int32_t width, int32_t height);
+
 DLLEXPORT const char** MediaParse(Dart_Handle object, const char* type,
                                   const char* resource, int32_t timeout);
 
@@ -120,7 +123,7 @@ DLLEXPORT DartDeviceList* DevicesAll(Dart_Handle object);
 DLLEXPORT struct DartEqualizer* EqualizerCreateEmpty(Dart_Handle object);
 
 DLLEXPORT struct DartEqualizer* EqualizerCreateMode(Dart_Handle object,
-                                                int32_t mode);
+                                                    int32_t mode);
 
 DLLEXPORT void EqualizerSetBandAmp(int32_t id, float band, float amp);
 

--- a/dartvlc/internal/setters.h
+++ b/dartvlc/internal/setters.h
@@ -197,6 +197,10 @@ class PlayerSetters : public PlayerEvents {
     OnPlaylistCallback();
   }
 
+  void TakeSnapshot(std::string file_path, int32_t width, int32_t height) {
+    vlc_media_player_.takeSnapshot(0, file_path, width, height);
+  }
+
   void SetVideoWidth(int32_t video_width) {
     preferred_video_width_ = video_width;
   }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -15,6 +15,7 @@ class DartVLCExample extends StatefulWidget {
 
 class DartVLCExampleState extends State<DartVLCExample> {
   Player player = Player(id: 0);
+  GlobalKey<VideoState> videoKey = GlobalKey<VideoState>();
   MediaType mediaType = MediaType.file;
   CurrentState current = new CurrentState();
   PositionState position = new PositionState();
@@ -83,6 +84,7 @@ class DartVLCExampleState extends State<DartVLCExample> {
                   clipBehavior: Clip.antiAlias,
                   elevation: 2.0,
                   child: Video(
+                    key: videoKey,
                     player: player,
                     width: 640,
                     height: 480,
@@ -603,6 +605,31 @@ class DartVLCExampleState extends State<DartVLCExample> {
                               Divider(
                                 height: 12.0,
                                 color: Colors.transparent,
+                              ),
+                              Row(
+                                children: [
+                                  ElevatedButton(
+                                    onPressed: () => videoKey.currentState
+                                        ?.enterFullscreen(),
+                                    child: Text(
+                                      'enterFullscreen',
+                                      style: TextStyle(
+                                        fontSize: 14.0,
+                                      ),
+                                    ),
+                                  ),
+                                  SizedBox(width: 12.0),
+                                  ElevatedButton(
+                                    onPressed: () =>
+                                        videoKey.currentState?.exitFullscreen(),
+                                    child: Text(
+                                      'exitFullscreen',
+                                      style: TextStyle(
+                                        fontSize: 14.0,
+                                      ),
+                                    ),
+                                  ),
+                                ],
                               ),
                               Divider(
                                 height: 12.0,

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -608,6 +608,7 @@ class DartVLCExampleState extends State<DartVLCExample> {
                               ),
                               Row(
                                 children: [
+                                  SizedBox(width: 12.0),
                                   ElevatedButton(
                                     onPressed: () => videoKey.currentState
                                         ?.enterFullscreen(),

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -35,14 +35,14 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.1.4"
+    version: "0.1.5"
   dart_vlc_ffi:
     dependency: transitive
     description:
       path: "../ffi"
       relative: true
     source: path
-    version: "0.1.2"
+    version: "0.1.3"
   ffi:
     dependency: transitive
     description:
@@ -158,6 +158,15 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.3"
+  window_size:
+    dependency: transitive
+    description:
+      path: "plugins/window_size"
+      ref: da98a3b5a0e2b9425fbcb2a3e4b4ba50754abf93
+      resolved-ref: da98a3b5a0e2b9425fbcb2a3e4b4ba50754abf93
+      url: "git://github.com/alexmercerind/flutter-desktop-embedding.git"
+    source: git
+    version: "0.1.0"
   xdg_directories:
     dependency: transitive
     description:

--- a/example/windows/flutter/generated_plugin_registrant.cc
+++ b/example/windows/flutter/generated_plugin_registrant.cc
@@ -5,8 +5,11 @@
 #include "generated_plugin_registrant.h"
 
 #include <dart_vlc/dart_vlc_plugin.h>
+#include <window_size/window_size_plugin.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
   DartVlcPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("DartVlcPlugin"));
+  WindowSizePluginRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("WindowSizePlugin"));
 }

--- a/example/windows/flutter/generated_plugins.cmake
+++ b/example/windows/flutter/generated_plugins.cmake
@@ -4,6 +4,7 @@
 
 list(APPEND FLUTTER_PLUGIN_LIST
   dart_vlc
+  window_size
 )
 
 set(PLUGIN_BUNDLED_LIBRARIES)

--- a/ffi/lib/src/internal/ffi.dart
+++ b/ffi/lib/src/internal/ffi.dart
@@ -100,6 +100,10 @@ abstract class PlayerFFI {
   static final PlayerMoveDart move = dynamicLibrary
       .lookup<NativeFunction<PlayerMoveCXX>>('PlayerMove')
       .asFunction();
+
+  static final PlayerTakeSnapshotDart takeSnapshot = dynamicLibrary
+      .lookup<NativeFunction<PlayerTakeSnapshotCXX>>('PlayerTakeSnapshot')
+      .asFunction();
 }
 
 abstract class MediaFFI {

--- a/ffi/lib/src/internal/typedefs/player.dart
+++ b/ffi/lib/src/internal/typedefs/player.dart
@@ -54,3 +54,7 @@ typedef PlayerMoveCXX = Void Function(
     Int32 id, Int32 initialIndex, Int32 finalIndex);
 typedef PlayerMoveDart = void Function(
     int id, int initialIndex, int finalIndex);
+typedef PlayerTakeSnapshotCXX = Void Function(
+    Int32 id, Pointer<Utf8> filePath, Int32 width, Int32 height);
+typedef PlayerTakeSnapshotDart = void Function(
+    int id, Pointer<Utf8> filePath, int width, int height);

--- a/ffi/lib/src/player.dart
+++ b/ffi/lib/src/player.dart
@@ -1,3 +1,4 @@
+import 'dart:io';
 import 'dart:async';
 import 'package:ffi/ffi.dart';
 import 'package:dart_vlc_ffi/dart_vlc_ffi.dart';
@@ -267,6 +268,11 @@ class Player {
   /// Sets [Equalizer] for the [Player].
   void setEqualizer(Equalizer equalizer) {
     PlayerFFI.setEqualizer(this.id, equalizer.id);
+  }
+
+  /// Saves snapshot of a video to a desired [File] location.
+  void takeSnapshot(File file, int width, int height) {
+    PlayerFFI.takeSnapshot(this.id, file.path.toNativeUtf8(), width, height);
   }
 
   /// Destroys the instance of [Player] & closes all [StreamController]s in it.

--- a/lib/dart_vlc.dart
+++ b/lib/dart_vlc.dart
@@ -103,15 +103,16 @@ abstract class DartVLC {
       final libraryPath = path.join(
           path.dirname(Platform.resolvedExecutable), 'dart_vlc_plugin.dll');
       FFI.DartVLC.initialize(libraryPath);
-    }
-    else if (Platform.isLinux) {
+    } else if (Platform.isLinux) {
       final libraryPath = path.join(path.dirname(Platform.resolvedExecutable),
           'lib', 'libdart_vlc_plugin.so');
       FFI.DartVLC.initialize(libraryPath);
-    }
-    else if(Platform.isMacOS) {
-      final libraryPath = path.join(path.dirname(path.dirname(Platform.resolvedExecutable)),
-          'Frameworks', 'dart_vlc.framework', 'dart_vlc');
+    } else if (Platform.isMacOS) {
+      final libraryPath = path.join(
+          path.dirname(path.dirname(Platform.resolvedExecutable)),
+          'Frameworks',
+          'dart_vlc.framework',
+          'dart_vlc');
       FFI.DartVLC.initialize(libraryPath);
     }
   }

--- a/lib/src/widgets/controls.dart
+++ b/lib/src/widgets/controls.dart
@@ -5,6 +5,7 @@ import 'package:audio_video_progress_bar/audio_video_progress_bar.dart';
 import 'package:dart_vlc_ffi/src/device.dart';
 import 'package:dart_vlc_ffi/src/player.dart';
 import 'package:dart_vlc_ffi/src/playerState/playerState.dart';
+import 'package:window_size/window_size.dart';
 
 class Control extends StatefulWidget {
   final Widget child;
@@ -21,6 +22,9 @@ class Control extends StatefulWidget {
   final Color? volumeInactiveColor;
   final Color? volumeBackgroundColor;
   final Color? volumeThumbColor;
+  final bool isFullscreen;
+  final void Function() enterFullscreen;
+  final void Function() exitFullscreen;
 
   Control({
     required this.child,
@@ -37,6 +41,9 @@ class Control extends StatefulWidget {
     required this.volumeInactiveColor,
     required this.volumeBackgroundColor,
     required this.volumeThumbColor,
+    required this.isFullscreen,
+    required this.enterFullscreen,
+    required this.exitFullscreen,
     Key? key,
   }) : super(key: key);
 
@@ -122,6 +129,30 @@ class ControlState extends State<Control> with SingleTickerProviderStateMixin {
                             Color(0xCC000000),
                           ],
                         ),
+                      ),
+                    ),
+                    Positioned(
+                      left: 16,
+                      bottom: 10,
+                      child: Row(
+                        crossAxisAlignment: CrossAxisAlignment.end,
+                        children: [
+                          IconButton(
+                            color: Colors.white,
+                            iconSize: 30,
+                            icon: Icon(
+                              widget.isFullscreen
+                                  ? Icons.fullscreen_exit
+                                  : Icons.fullscreen,
+                            ),
+                            onPressed: () {
+                              if (widget.isFullscreen)
+                                widget.exitFullscreen();
+                              else
+                                widget.enterFullscreen();
+                            },
+                          ),
+                        ],
                       ),
                     ),
                     Positioned(
@@ -258,8 +289,8 @@ class ControlState extends State<Control> with SingleTickerProviderStateMixin {
                       ),
                     ),
                     Positioned(
-                      right: 15,
-                      bottom: 12.5,
+                      right: 16,
+                      bottom: 10,
                       child: Row(
                         crossAxisAlignment: CrossAxisAlignment.end,
                         children: [
@@ -271,7 +302,7 @@ class ControlState extends State<Control> with SingleTickerProviderStateMixin {
                             backgroundColor: widget.volumeBackgroundColor,
                           ),
                           PopupMenuButton(
-                            iconSize: 24,
+                            iconSize: 28,
                             icon: Icon(Icons.speaker, color: Colors.white),
                             onSelected: (Device device) {
                               players[widget.playerId]!.setDevice(device);
@@ -370,7 +401,6 @@ class _VolumeControlState extends State<VolumeControl> {
                 setState(() => _showVolume = false);
               },
               child: Container(
-                width: 60,
                 height: 250,
                 child: Card(
                   color: widget.backgroundColor,
@@ -409,6 +439,7 @@ class _VolumeControlState extends State<VolumeControl> {
           },
           child: IconButton(
             color: Colors.white,
+            iconSize: 28.0,
             onPressed: () => muteUnmute(),
             icon: Icon(getIcon()),
           ),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -25,10 +25,10 @@ packages:
   dart_vlc_ffi:
     dependency: "direct main"
     description:
-      path: ffi
-      relative: true
-    source: path
-    version: "0.1.2"
+      name: dart_vlc_ffi
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.3"
   ffi:
     dependency: transitive
     description:
@@ -144,6 +144,15 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.3"
+  window_size:
+    dependency: "direct main"
+    description:
+      path: "plugins/window_size"
+      ref: da98a3b5a0e2b9425fbcb2a3e4b4ba50754abf93
+      resolved-ref: da98a3b5a0e2b9425fbcb2a3e4b4ba50754abf93
+      url: "git://github.com/alexmercerind/flutter-desktop-embedding.git"
+    source: git
+    version: "0.1.0"
   xdg_directories:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -25,9 +25,9 @@ packages:
   dart_vlc_ffi:
     dependency: "direct main"
     description:
-      name: dart_vlc_ffi
-      url: "https://pub.dartlang.org"
-    source: hosted
+      path: ffi
+      relative: true
+    source: path
     version: "0.1.3"
   ffi:
     dependency: transitive

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,6 +16,11 @@ dependencies:
   path: ^1.8.0
   path_provider: ^2.0.1
   audio_video_progress_bar: ^0.4.0
+  window_size:
+    git:
+      url: git://github.com/alexmercerind/flutter-desktop-embedding.git
+      path: plugins/window_size
+      ref: da98a3b5a0e2b9425fbcb2a3e4b4ba50754abf93
 
 flutter:
   # No platform channel implementation after migration to FFI.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  dart_vlc_ffi: ^0.1.3
+  dart_vlc_ffi:
+    path: ./ffi
   path: ^1.8.0
   path_provider: ^2.0.1
   audio_video_progress_bar: ^0.4.0


### PR DESCRIPTION
- Adds fullscreen controls to `Video` widget, when `showControls` is passed as true.
- Adds `enterFullscreen` and `exitFullscreen` to `Video` Widget (which can be accessed with `GlobalKey`), in case one wants deeper control over the thing.
- Updated example with the same.
- Only works on Windows & Linux. (Because my fork of `window_size` doesn't have macOS support & Google hasn't merged to master yet on their main repo).
- Exposes `libvlc_video_take_snapshot`.