### PR TITLE
Prepare fullscreen support

### DIFF
--- a/lib/dart_vlc.dart
+++ b/lib/dart_vlc.dart
@@ -20,6 +20,7 @@ import 'package:dart_vlc_ffi/src/internal/ffi.dart' as FFI;
 import 'package:dart_vlc_ffi/dart_vlc_ffi.dart' as FFI;
 export 'package:dart_vlc_ffi/dart_vlc_ffi.dart' hide DartVLC, Player;
 export 'package:dart_vlc/src/widgets/video.dart';
+export 'package:dart_vlc/src/widgets/controls.dart';
 
 /// Platform channel for using [Texture] & flutter::TextureRegistrar on Windows.
 final MethodChannel _channel = MethodChannel('dart_vlc');
@@ -103,15 +104,16 @@ abstract class DartVLC {
       final libraryPath = path.join(
           path.dirname(Platform.resolvedExecutable), 'dart_vlc_plugin.dll');
       FFI.DartVLC.initialize(libraryPath);
-    }
-    else if (Platform.isLinux) {
+    } else if (Platform.isLinux) {
       final libraryPath = path.join(path.dirname(Platform.resolvedExecutable),
           'lib', 'libdart_vlc_plugin.so');
       FFI.DartVLC.initialize(libraryPath);
-    }
-    else if(Platform.isMacOS) {
-      final libraryPath = path.join(path.dirname(path.dirname(Platform.resolvedExecutable)),
-          'Frameworks', 'dart_vlc.framework', 'dart_vlc');
+    } else if (Platform.isMacOS) {
+      final libraryPath = path.join(
+          path.dirname(path.dirname(Platform.resolvedExecutable)),
+          'Frameworks',
+          'dart_vlc.framework',
+          'dart_vlc');
       FFI.DartVLC.initialize(libraryPath);
     }
   }

--- a/lib/src/widgets/controls.dart
+++ b/lib/src/widgets/controls.dart
@@ -6,9 +6,30 @@ import 'package:dart_vlc_ffi/src/device.dart';
 import 'package:dart_vlc_ffi/src/player.dart';
 import 'package:dart_vlc_ffi/src/playerState/playerState.dart';
 
+class FullscreenState {
+  final bool isFullscreen;
+  final bool isFullscreenAllowed;
+  const FullscreenState(
+      {required this.isFullscreen, required this.isFullscreenAllowed});
+
+  FullscreenState copyWith({bool? isFullscreen, bool? isFullscreenAllowed}) =>
+      FullscreenState(
+          isFullscreen: isFullscreen ?? this.isFullscreen,
+          isFullscreenAllowed: isFullscreenAllowed ?? this.isFullscreenAllowed);
+}
+
+abstract class FullscreenController extends ValueNotifier<FullscreenState> {
+  FullscreenController()
+      : super(FullscreenState(isFullscreenAllowed: true, isFullscreen: false));
+
+  bool get isFullscreen => value.isFullscreen;
+  void toggleFullscreen();
+}
+
 class Control extends StatefulWidget {
   final Widget child;
   final Player player;
+  final FullscreenController? fullscreenController;
   final bool? showTimeLeft;
   final double? progressBarThumbRadius;
   final double? progressBarThumbGlowRadius;
@@ -25,6 +46,7 @@ class Control extends StatefulWidget {
   Control({
     required this.child,
     required this.player,
+    this.fullscreenController,
     required this.showTimeLeft,
     required this.progressBarThumbRadius,
     required this.progressBarThumbGlowRadius,
@@ -124,6 +146,34 @@ class ControlState extends State<Control> with SingleTickerProviderStateMixin {
                         ),
                       ),
                     ),
+                    if (widget.fullscreenController != null)
+                      Positioned(
+                        left: 16,
+                        bottom: 10,
+                        child: Row(
+                          crossAxisAlignment: CrossAxisAlignment.end,
+                          children: [
+                            ValueListenableBuilder<FullscreenState>(
+                                valueListenable: widget.fullscreenController!,
+                                builder: (context, state, _) => IconButton(
+                                      color: Colors.white,
+                                      disabledColor: Colors.white,
+                                      iconSize: 30,
+                                      icon: Icon(
+                                        state.isFullscreen
+                                            ? Icons.fullscreen_exit
+                                            : Icons.fullscreen,
+                                      ),
+                                      onPressed: state.isFullscreenAllowed
+                                          ? () {
+                                              widget.fullscreenController
+                                                  ?.toggleFullscreen();
+                                            }
+                                          : null,
+                                    )),
+                          ],
+                        ),
+                      ),
                     Positioned(
                       left: 0,
                       right: 0,
@@ -247,8 +297,8 @@ class ControlState extends State<Control> with SingleTickerProviderStateMixin {
                       ),
                     ),
                     Positioned(
-                      right: 15,
-                      bottom: 12.5,
+                      right: 16,
+                      bottom: 10,
                       child: Row(
                         crossAxisAlignment: CrossAxisAlignment.end,
                         children: [
@@ -260,7 +310,7 @@ class ControlState extends State<Control> with SingleTickerProviderStateMixin {
                             backgroundColor: widget.volumeBackgroundColor,
                           ),
                           PopupMenuButton(
-                            iconSize: 24,
+                            iconSize: 28,
                             icon: Icon(Icons.speaker, color: Colors.white),
                             onSelected: (Device device) {
                               player.setDevice(device);
@@ -361,7 +411,6 @@ class _VolumeControlState extends State<VolumeControl> {
                 setState(() => _showVolume = false);
               },
               child: Container(
-                width: 60,
                 height: 250,
                 child: Card(
                   color: widget.backgroundColor,
@@ -400,6 +449,7 @@ class _VolumeControlState extends State<VolumeControl> {
           },
           child: IconButton(
             color: Colors.white,
+            iconSize: 28,
             onPressed: () => muteUnmute(),
             icon: Icon(getIcon()),
           ),

--- a/lib/src/widgets/video.dart
+++ b/lib/src/widgets/video.dart
@@ -21,7 +21,7 @@ class VideoFrame {
   final int videoHeight;
   final Uint8List byteArray;
 
-  VideoFrame({
+  const VideoFrame({
     required this.playerId,
     required this.videoWidth,
     required this.videoHeight,
@@ -87,42 +87,45 @@ class Video extends StatefulWidget {
   // Built-In video controls.
   final bool showControls;
 
-  // Radius of the progressbar's thumb
+  /// Radius of the progressbar's thumb
   final double? progressBarThumbRadius;
 
-  // Radius of the progressbar's glow of the thumb
+  /// Radius of the progressbar's glow of the thumb
   final double? progressBarThumbGlowRadius;
 
-  // Active color of the progress bar
+  /// Active color of the progress bar
   final Color? progressBarActiveColor;
 
-  // Inactive color of the progress bar
+  /// Inactive color of the progress bar
   final Color? progressBarInactiveColor;
 
-  // Thumb color of the progress bar
+  /// Thumb color of the progress bar
   final Color? progressBarThumbColor;
 
   // Thumb's glow color of the progress bar
   final Color? progressBarThumbGlowColor;
 
-  // TextStyle for the Progress Bar
+  /// TextStyle for the Progress Bar
   final TextStyle progressBarTextStyle;
 
-  // Active color of the volume slider
+  /// Active color of the volume slider
   final Color? volumeActiveColor;
 
-  // Inactive color of the volume slider
+  /// Inactive color of the volume slider
   final Color? volumeInactiveColor;
 
-  // Background color of the volume slider
+  /// Background color of the volume slider
   final Color volumeBackgroundColor;
 
-  // Thumb color of the volume slider
+  /// Thumb color of the volume slider
   final Color? volumeThumbColor;
 
-  // if you want the progress bar to display the time left while playing
-  // instead of the total time, set this to true
+  /// if you want the progress bar to display the time left while playing
+  /// instead of the total time, set this to true
   final bool showTimeLeft;
+
+  /// An optional [FullscreenController].
+  final FullscreenController? fullscreenController;
 
   Video({
     @Deprecated('playerId is deprecated. Use player instead.') int? playerId,
@@ -146,6 +149,7 @@ class Video extends StatefulWidget {
     this.showTimeLeft = false,
     this.progressBarTextStyle = const TextStyle(),
     this.filterQuality = FilterQuality.low,
+    this.fullscreenController,
     Key? key,
   })  : player = player ?? players[playerId]! as Player,
         super(key: key);
@@ -175,6 +179,7 @@ abstract class _VideoStateBase extends State<Video> {
             ? Control(
                 key: controlKey,
                 player: widget.player,
+                fullscreenController: widget.fullscreenController,
                 progressBarThumbRadius: widget.progressBarThumbRadius,
                 progressBarThumbGlowRadius: widget.progressBarThumbGlowRadius,
                 progressBarActiveColor: widget.progressBarActiveColor,
@@ -209,7 +214,6 @@ class _VideoStateTexture extends _VideoStateBase {
       });
     });
     super.initState();
-    if (mounted) setState(() {});
   }
 
   Widget present() {
@@ -283,7 +287,6 @@ class _VideoStateFallback extends _VideoStateBase {
       if (mounted) setState(() {});
     });
     super.initState();
-    if (mounted) setState(() {});
   }
 
   Widget present() {


### PR DESCRIPTION
@alexmercerind 
I was a bit tired of arguing, so I made this proposal showing how fullscreen handling might be decoupled from the `Video` widget.

It allows you to pass an optional `FullscreenController` upon creating a `Video` widget:
```dart
Video(player: _player, fullscreenController: MyFullscreenController());
```

The button for toggling fullscreen will only appear if a controller was provided. (I've just added your proposed button from yesterday's PR)

A very basic implementation using your `window_size` fork might look like
```dart
class MyFullscreenController extends FullscreenController {
  @override
  void toggleFullscreen() {
    final isFullscreen = value.isFullscreen;
    if (isFullscreen) {
      window.exitFullscreen();
    } else {
      window.enterFullscreen();
    }

    value = value.copyWith(isFullscreen: !value.isFullscreen);
  }
}
```
