### PR TITLE
wrapper API: rework OnOpen callback

### DIFF
--- a/ffi/CHANGELOG.md
+++ b/ffi/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.4
+
+- Fix OnOpen callback
+
 ## 0.1.3
 
 - Update `ReceivePort` listener to match new NativePort callbacks.

--- a/ffi/lib/src/internal/ffi.dart
+++ b/ffi/lib/src/internal/ffi.dart
@@ -228,22 +228,24 @@ final ReceivePort receiver = new ReceivePort()
         {
           players[id]!.current.index = event[2];
           players[id]!.current.isPlaylist = event[3];
+          assert(event[4].length == event[5].length);
+          int length = event[4].length;
           List<Media> medias = [];
-          for (int index = 4; index < event.length; index += 2) {
-            switch (event[index]) {
+          for (int index = 0; index < length; index++) {
+            switch (event[4][index]) {
               case 'MediaType.file':
                 {
-                  medias.add(Media.file(File(event[index + 1])));
+                  medias.add(Media.file(File(event[5][index])));
                   break;
                 }
               case 'MediaType.network':
                 {
-                  medias.add(Media.network(Uri.parse(event[index + 1])));
+                  medias.add(Media.network(Uri.parse(event[5][index])));
                   break;
                 }
               case 'MediaType.directShow':
                 {
-                  medias.add(Media.directShow(rawUrl: event[index + 1]));
+                  medias.add(Media.directShow(rawUrl: event[5][index]));
                   break;
                 }
             }

--- a/ffi/pubspec.yaml
+++ b/ffi/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_vlc_ffi
 description: FFI based binding to dart_vlc wrapper (Based on libVLC & libVLC++).
-version: 0.1.3
+version: 0.1.4
 homepage: https://github.com/alexmercerind/dart_vlc
 repository: https://github.com/alexmercerind/dart_vlc
 documentation: https://github.com/alexmercerind/dart_vlc/blob/master/README.md

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: audio_video_progress_bar
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.0"
+    version: "0.9.0"
   characters:
     dependency: transitive
     description:
@@ -25,10 +25,10 @@ packages:
   dart_vlc_ffi:
     dependency: "direct main"
     description:
-      name: dart_vlc_ffi
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.1.3"
+      path: ffi
+      relative: true
+    source: path
+    version: "0.1.4"
   ffi:
     dependency: transitive
     description:
@@ -68,7 +68,7 @@ packages:
       name: path_provider
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.1"
+    version: "2.0.2"
   path_provider_linux:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_vlc
 description: Flutter media playback, broadcast, recording & chromecast library. Based on libVLC & libVLC++.
-version: 0.1.6
+version: 0.1.7
 homepage: https://github.com/alexmercerind/dart_vlc
 repository: https://github.com/alexmercerind/dart_vlc
 documentation: https://github.com/alexmercerind/dart_vlc/blob/master/README.md
@@ -12,7 +12,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  dart_vlc_ffi: ">=0.1.3 <1.0.0"
+  dart_vlc_ffi:
+   path: ./ffi
   path: ">=1.8.0 <2.0.0"
   path_provider: ">=2.0.2 <3.0.0"
   audio_video_progress_bar: ">=0.9.0 <1.0.0"


### PR DESCRIPTION
[WIP]

Fixes crash from happening in release mode, when calling `Player::Open` (which causes some memory error in `OnOpen`). This works, looks cleaner.

There is still some other issue that very randomly causes crash e.g. calling `Player::Next` or `Player::Back` etc.