### PR TITLE
Fix: Create new texture when video frame size is changed.

### DIFF
--- a/dartvlc/api/api.cc
+++ b/dartvlc/api/api.cc
@@ -73,9 +73,11 @@ void PlayerCreate(int32_t id, int32_t video_width, int32_t video_height,
 /* Windows: Texture & flutter::TextureRegistrar */
 #else
   /* Linux: decodeImageFromPixels & NativePorts */
-  player->OnVideo([=](uint8_t* frame, int32_t width, int32_t height) -> void {
-    OnVideo(id, player->video_width() * player->video_height() * 4, frame);
-  });
+  player->OnVideo(
+      [=](uint8_t* frame, int32_t width, int32_t height) -> void {
+        OnVideo(id, player->video_width() * player->video_height() * 4, frame);
+      },
+      [](int32_t, int32_t) -> void {});
 #endif
   player->OnVideoDimensions(
       [=](int32_t video_width, int32_t video_height) -> void {

--- a/windows/video_outlet.cc
+++ b/windows/video_outlet.cc
@@ -1,7 +1,14 @@
 #include "video_outlet.h"
 
-VideoOutlet::VideoOutlet(flutter::TextureRegistrar* texture_registrar)
-    : texture_registrar_(texture_registrar) {
+VideoOutlet::VideoOutlet(
+    int32_t player_id, flutter::TextureRegistrar* texture_registrar,
+    flutter::MethodChannel<flutter::EncodableValue>* channel)
+    : player_id_(player_id),
+      texture_registrar_(texture_registrar),
+      channel_(channel) {}
+
+int64_t VideoOutlet::CreateNewTexture() {
+  DeleteTexture();
   texture_ =
       std::make_unique<flutter::TextureVariant>(flutter::PixelBufferTexture(
           [=](size_t width, size_t height) -> const FlutterDesktopPixelBuffer* {
@@ -9,16 +16,35 @@ VideoOutlet::VideoOutlet(flutter::TextureRegistrar* texture_registrar)
             return &flutter_pixel_buffer_;
           }));
   texture_id_ = texture_registrar_->RegisterTexture(texture_.get());
+  return texture_id_.value();
+}
+
+void VideoOutlet::DeleteTexture() {
+  // Prevents calling `UnregisterTexture` if no texture was ever registered.
+  if (texture_id_.has_value()) {
+    channel_->InvokeMethod(
+        "PlayerTextureId",
+        std::make_unique<flutter::EncodableValue>(flutter::EncodableMap(
+            {{"playerId", player_id_}, {"textureId", nullptr}})));
+    texture_registrar_->UnregisterTexture(texture_id_.value());
+    texture_id_ = std::nullopt;
+  }
 }
 
 void VideoOutlet::OnVideo(uint8_t* buffer, int32_t width, int32_t height) {
+  if (width_ != width && height_ != height) {
+    channel_->InvokeMethod(
+        "PlayerTextureId",
+        std::make_unique<flutter::EncodableValue>(flutter::EncodableMap(
+            {{"playerId", player_id_}, {"textureId", CreateNewTexture()}})));
+    width_ = width;
+    height_ = height;
+  }
   const std::lock_guard<std::mutex> lock(mutex_);
   flutter_pixel_buffer_.buffer = buffer;
   flutter_pixel_buffer_.width = width;
   flutter_pixel_buffer_.height = height;
-  texture_registrar_->MarkTextureFrameAvailable(texture_id_);
+  texture_registrar_->MarkTextureFrameAvailable(texture_id_.value());
 }
 
-VideoOutlet::~VideoOutlet() {
-  texture_registrar_->UnregisterTexture(texture_id_);
-}
+VideoOutlet::~VideoOutlet() { DeleteTexture(); }

--- a/windows/video_outlet.h
+++ b/windows/video_outlet.h
@@ -9,19 +9,28 @@
 
 class VideoOutlet {
  public:
-  VideoOutlet(flutter::TextureRegistrar* texture_registrar);
+  VideoOutlet(int32_t player_id, flutter::TextureRegistrar* texture_registrar,
+              flutter::MethodChannel<flutter::EncodableValue>* channel);
 
-  int64_t texture_id() const { return texture_id_; }
+  int64_t texture_id() const { return texture_id_.value(); }
+
+  void DeleteTexture();
+
+  int64_t CreateNewTexture();
 
   void OnVideo(uint8_t* buffer, int32_t width, int32_t height);
 
   ~VideoOutlet();
 
  private:
+  int32_t player_id_;
   FlutterDesktopPixelBuffer flutter_pixel_buffer_{};
   flutter::TextureRegistrar* texture_registrar_ = nullptr;
+  flutter::MethodChannel<flutter::EncodableValue>* channel_;
   std::unique_ptr<flutter::TextureVariant> texture_ = nullptr;
-  int64_t texture_id_;
+  std::optional<int64_t> texture_id_ = std::nullopt;
+  std::optional<int32_t> width_ = std::nullopt;
+  std::optional<int32_t> height_ = std::nullopt;
   mutable std::mutex mutex_;
 };
 


### PR DESCRIPTION
[WIP]

- Add `VideoResizeCallback` to `Player::OnVideo` listener, to get callback ahead of buffer reallocation (if the frame size is changed).
- Now PlayerRegisterTexture & PlayerUnregisterTexture are renamed to PlayerCreateVideoOutlet & PlayerDeleteVideoOutlet.
- Now method channel call no longer creates texture ahead of time, but when first frame of the video is received.
- If a new media of different video dimensions is opened, the previous texture is deleted & new is created (`VideoOutlet::CreateNewTexture`), whose texture ID is notified through the method channel.
- Currently `UnregisterTexture` is causing exception (from `VideoOutlet::DeleteTexture`).
  - Not sure about the reason.
  - Although I'm sure that I'm NOT deleting the texture ID which was never created.

![Screenshot 2021-08-25 171022](https://user-images.githubusercontent.com/28951144/130784437-49ad423b-cec3-4d68-b64a-7758644cb28d.png)
