### PR TITLE
fix close window cause crash when playing on Windows

### DIFF
--- a/windows/dart_vlc_plugin.cc
+++ b/windows/dart_vlc_plugin.cc
@@ -61,7 +61,14 @@ DartVlcPlugin::DartVlcPlugin(
     flutter::TextureRegistrar* texture_registrar)
     : channel_(std::move(channel)), texture_registrar_(texture_registrar) {}
 
-DartVlcPlugin::~DartVlcPlugin() {}
+DartVlcPlugin::~DartVlcPlugin() {
+  // Clean up unreleased players when the flutter engine is destroyed to avoid crashes.
+  for (const auto& [player_id, outlet] : outlets_) {
+    Player* player = g_players->Get(player_id);
+    player->OnVideo(nullptr);
+    g_players->Dispose(player_id);
+  }
+}
 
 void DartVlcPlugin::HandleMethodCall(
     const flutter::MethodCall<flutter::EncodableValue>& method_call,


### PR DESCRIPTION
On Windows, it will rasied a crash if we close the window when video is playing. 

<img width="1562" alt="crash" src="https://user-images.githubusercontent.com/17426470/149311011-0c480f5b-3049-4363-b03b-bed08ec471f6.png">

This might not be a problem for a normal flutter single window app, but I'm trying use a new window to play the video, so...
