### PR TITLE
Update window_manager dependency version

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   path_provider: ">=2.0.2 <3.0.0"
   audio_video_progress_bar: ">=0.9.0 <1.0.0"
   flutter_native_view: ^0.0.1+1
-  window_manager: ^0.2.2
+  window_manager: ^0.2.3
 
 # REMOVE THIS BEFORE PUBLISHING ON pub.dev.
 dependency_overrides:


### PR DESCRIPTION
Fix - https://github.com/alexmercerind/dart_vlc/issues/269
Please update the package version so that macOS build will not fail.